### PR TITLE
Add test to catch devices that are missing local key

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -456,26 +456,32 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
         # https://developer.tuya.com/en/docs/cloud/303a03de7e?id=Kb2us379ab2mi
         gateways = {}
         for dev_id, dev in data[DATA_CLOUD].device_list.items():
-            if dev['category'] == 'wg2':
+            if dev['category'] in ['wg2', 'wfcon']:
                 # identify gateways by local key since sub-devices under
                 # this gateway use the gateway local key
                 gateways[dev['local_key']] = dev_id
+                _LOGGER.debug(dev['category'])
+                _LOGGER.debug(dev['local_key'])
 
         devices = {}
         for dev_id, dev in data[DATA_CLOUD].device_list.items():
             if dev_id not in self.config_entry.data[CONF_DEVICES]:
                 if dev_id in discovered_devices:
                     devices[dev_id] = discovered_devices[dev_id]["ip"]
-                elif dev['local_key'] in gateways:
-                    gateway_id = gateways[dev['local_key']]
-                    # this device uses the gateway api for communication
-                    discovered_devices[dev_id] = discovered_devices[gateway_id].copy()
-                    discovered_devices[dev_id][CONF_GATEWAY_DEVICE_ID] = discovered_devices[gateway_id]['gwId']
-                    devices[dev_id] = discovered_devices[gateway_id]["ip"]
-                    # this should be the mac address of the sub device
-                    discovered_devices[dev_id][CONF_CLIENT_ID] = dev['node_id']
-                    # keep the original device id in the gwId
-                    discovered_devices[dev_id]['gwId'] = dev_id
+                else:
+                    if 'local_key' in dev:
+                        if dev['local_key'] in gateways:
+                            gateway_id = gateways[dev['local_key']]
+                            # this device uses the gateway api for communication
+                            discovered_devices[dev_id] = discovered_devices[gateway_id].copy()
+                            discovered_devices[dev_id][CONF_GATEWAY_DEVICE_ID] = discovered_devices[gateway_id]['gwId']
+                            devices[dev_id] = discovered_devices[gateway_id]["ip"]
+                            # this should be the mac address of the sub device
+                            discovered_devices[dev_id][CONF_CLIENT_ID] = dev['node_id']
+                            # keep the original device id in the gwId
+                            discovered_devices[dev_id]['gwId'] = dev_id
+                    else:
+                        _LOGGER.info("localtuya: " + dev_id + " - Device has no local_key")
 
         self.discovered_devices = discovered_devices
 

--- a/custom_components/localtuya/number.py
+++ b/custom_components/localtuya/number.py
@@ -10,8 +10,8 @@ from .common import LocalTuyaEntity, async_setup_entry
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_MIN_VALUE = "min_value"
-CONF_MAX_VALUE = "max_value"
+CONF_MIN_VALUE = "native_min_value"
+CONF_MAX_VALUE = "native_max_value"
 
 DEFAULT_MIN = 0
 DEFAULT_MAX = 100000
@@ -52,17 +52,17 @@ class LocaltuyaNumber(LocalTuyaEntity, NumberEntity):
         self._max_value = self._config.get(CONF_MAX_VALUE)
 
     @property
-    def value(self) -> float:
+    def native_value(self) -> float:
         """Return sensor state."""
         return self._state
 
     @property
-    def min_value(self) -> float:
+    def native_min_value(self) -> float:
         """Return the minimum value."""
         return self._min_value
 
     @property
-    def max_value(self) -> float:
+    def native_max_value(self) -> float:
         """Return the maximum value."""
         return self._max_value
 
@@ -71,7 +71,7 @@ class LocaltuyaNumber(LocalTuyaEntity, NumberEntity):
         """Return the class of this device."""
         return self._config.get(CONF_DEVICE_CLASS)
 
-    async def async_set_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self._device.set_dp(value, self._dp_id)
 


### PR DESCRIPTION
I had a few Bluetooth devices that didn't register properly when adding them to my Tuya cloud account. They register but don't complete properly and the Tuya Cloud API call will return them but your code assumed they had a local_ley.  The add device steps in the integration will fail if there is no local_key and you then can't do anything with the integration.

Added a few lines to your common.py to catch this issue and log out the bad Device ID and enable the integration to continue working. 